### PR TITLE
chore: improve .gitignore (2026-03-17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,46 @@
+# Auto-generated .gitignore for Unknown
+
+# Code coverage reports
+coverage/
+
+# IntelliJ IDEA settings
+.idea/
+
+# macOS metadata
+.DS_Store
+
+# Windows thumbnail cache
+Thumbs.db
+
+# Log files
+*.log
+
+# Environment vars (secrets!)
+.env
+
+# Local env overrides
+.env.local
+
+# Vim swap files
+*.swp
+
+# Vim swap files
+*.swo
+
+# Backup files
+*~
+
+# Generic cache
+.cache/
+
+# Temporary files
+tmp/
+
+# OS / Editor
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+
+
+# ── Additional patterns (auto-detected) ──


### PR DESCRIPTION
## Automated .gitignore Improvement

### Changes:
- Created .gitignore with Unknown template + 0 extra patterns

### Why?
- Committed build artifacts bloat your repo and slow cloning
- They skew GitHub language statistics (e.g. showing mostly HTML)
- A proper .gitignore keeps things clean

### Action:
- **Merge** if it looks good, or **close** if you prefer to handle it yourself.

> Auto-generated on 2026-03-17